### PR TITLE
add dockerfile for britpol

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM r-base:4.1.2
+
+RUN apt-get update -y
+RUN apt-get install -y libgit2-dev git build-essential \
+    libcurl4-gnutls-dev libxml2-dev libssl-dev
+
+RUN R -e 'install.packages("devtools", repos="https://www.stats.bris.ac.uk/R/")'
+
+RUN R -e 'devtools::install_github("jackobailey/britpol")'
+
+WORKDIR /home/docker
+
+CMD ["R", "--no-save"]


### PR DESCRIPTION
Big fan of this package for some personal projects although found some trickiness when installing it on my M1 mac. Therefore I had a go at writing a Dockerfile to containerise the package to enable me to use it from within a container.

## Requirements

Need [Docker](https://docs.docker.com/get-docker/) installed on your machine.

## Usage

This is a simple Dockerfile that builds a container using the [r-base](https://hub.docker.com/_/r-base) image, installing some library dependencies before installing `devtools` and using `devtools` to install `britpol` form GitHub. On using `docker run` the container returns an R console from within the container from which you can use the `britpol` package.

### Building

You can build this locally with docker commands:

```bash
$ cd britpol/

$ docker build . -t britpol-docker:latest
```

### Running

After docker builds the image you can run it with the following commands:

```bash
$ docker run -it britpol-docker:latest
```

To mount your current directory on your host machine (to egress data):

```bash
$ docker run -it -v $PWD:/home/docker britpol-docker:latest
```

Let us know if you'd be interested in this PR at all and no worries if not.